### PR TITLE
fix: incorrect file name .env.template

### DIFF
--- a/bin/docker/setup
+++ b/bin/docker/setup
@@ -11,7 +11,7 @@ end
 FileUtils.chdir APP_ROOT do
   # This turns sets up up the docker image
   puts "\n== Copying sample files =="
-  FileUtils.cp ".env.template", ".env" unless File.exist?(".env")
+  FileUtils.cp ".env.example", ".env" unless File.exist?(".env")
 
   puts "== Pulling Images =="
   system! "docker-compose pull"


### PR DESCRIPTION
- File needs to be .env.example to match the template, or else this setup script won't run